### PR TITLE
Configure visual studio code settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csdevkit",
+    "ms-dotnettools.csharp",
+    "ms-vscode.vscode-typescript-next",
+    "ms-azuretools.vscode-docker",
+    "humao.rest-client",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,175 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Launch Mango.Web",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Web/Mango.Web.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.GatewaySolution",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.GatewaySolution/Mango.GatewaySolution.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.AuthAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.AuthAPI/Mango.Services.AuthAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.CouponAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.CouponAPI/Mango.Services.CouponAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.ProductAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.ProductAPI/Mango.Services.ProductAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.EmailAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.EmailAPI/Mango.Services.EmailAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.ShoppingCartAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.ShoppingCartAPI/Mango.Services.ShoppingCartAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.OrderAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.OrderAPI/Mango.Services.OrderAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": ".NET Launch Mango.Services.RewardAPI",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build (Debug)",
+      "program": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "Mango/Mango.Services.RewardAPI/Mango.Services.RewardAPI.csproj",
+        "--no-build"
+      ],
+      "cwd": "${workspaceFolder}",
+      "env": { "ASPNETCORE_ENVIRONMENT": "Development" },
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Run Web + Gateway + APIs",
+      "configurations": [
+        ".NET Launch Mango.Web",
+        ".NET Launch Mango.GatewaySolution",
+        ".NET Launch Mango.Services.AuthAPI",
+        ".NET Launch Mango.Services.CouponAPI",
+        ".NET Launch Mango.Services.ProductAPI",
+        ".NET Launch Mango.Services.EmailAPI",
+        ".NET Launch Mango.Services.ShoppingCartAPI",
+        ".NET Launch Mango.Services.OrderAPI",
+        ".NET Launch Mango.Services.RewardAPI"
+      ],
+      "stopAll": true
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "dotnet.defaultSolution": "Mango/Mango.sln",
+  "files.exclude": {
+    "**/bin": true,
+    "**/obj": true,
+    "**/node_modules": true
+  },
+  "search.exclude": {
+    "**/bin": true,
+    "**/obj": true
+  },
+  "csharp.suppressBuildAssetsEvaluation": true,
+  "csharp.inlayHints.parameters.enabled": true,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+  "dotnet.server.useOmnisharp": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json.schemastore.org/task.json",
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "dotnet restore (solution)",
+      "type": "process",
+      "command": "dotnet",
+      "args": ["restore", "Mango/Mango.sln"],
+      "group": "build",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "dotnet build (Debug)",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "Mango/Mango.sln",
+        "-c",
+        "Debug"
+      ],
+      "group": "build",
+      "dependsOn": ["dotnet restore (solution)"],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "dotnet build (Release)",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "Mango/Mango.sln",
+        "-c",
+        "Release"
+      ],
+      "group": "build",
+      "dependsOn": ["dotnet restore (solution)"],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "dotnet test",
+      "type": "process",
+      "command": "dotnet",
+      "args": ["test", "Mango/Mango.sln"],
+      "group": "test",
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
Add VS Code configuration files to enable building, debugging, and running the .NET 8 Mango solution.

---
<a href="https://cursor.com/background-agent?bcId=bc-d91a5c94-00d2-41d5-9a61-7a858cff5fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d91a5c94-00d2-41d5-9a61-7a858cff5fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

